### PR TITLE
Fixed tab size inconsistency

### DIFF
--- a/js/editor-cm.js
+++ b/js/editor-cm.js
@@ -150,6 +150,7 @@ EditorCodeMirror.prototype.setFontSize = function(fontSize) {
  */
 EditorCodeMirror.prototype.setTabSize = function(size) {
   this.cm_.setOption('tabSize', size);
+  this.cm_.setOption('indentUnit', size);
   this.replaceTabWithSpaces(this.settings_.get('spacestab'));
 };
 


### PR DESCRIPTION
Reported from user: _Setting the tab size to 4 allows me to press the tab key and have the cursor indent 4 spaces. That's great. However, if I highlight an unindented block of text and press Ctrl + { together so that the block becomes indented, I noticed the indent is just 2 spaces instead of the expected 4._

This patch fixes this issue.

TBR=@eterevsky
BUG=#261