### PR TITLE
Removed deprecated manifest file_handlers title

### DIFF
--- a/build.py
+++ b/build.py
@@ -114,10 +114,8 @@ def process_manifest(out_dir, version):
   manifest = json.load(open(os.path.join(SOURCE_DIR, MANIFEST)))
   if USE_LOCALIZED_NAME:
     manifest['name'] = '__MSG_extName__'
-    manifest['file_handlers']['text']['title'] = '__MSG_extName__'
   else:
     manifest['name'] = APP_NAME
-    manifest['file_handlers']['text']['title'] = APP_NAME
   manifest['version'] = version
 
   if IS_APP:

--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,6 @@
   ],
   "file_handlers": {
     "text": {
-      "title": "Text Dev",
       "types": ["application/javascript", "application/json", "application/x-shellscript", "application/xml", "text/*"],
       "extensions": ["asp", "aspx", "abc", "acgi", "aip", "asm", "c", "c++", "cc", "clj", "com", "coffee", "conf", "cpp", "cs", "csh", "css", "csv", "cxx", "def", "diff", "el", "ejs", "etx", "f", "f77", "f90", "flx", "for", "g", "gn", "gemspec", "go", "groovy", "gyp", "gypi", "h", "hh", "hlb", "hpp", "hs", "htc", "htm", "html", "htmls", "htt", "htx", "ics", "idc", "ifb", "jav", "java", "js", "json", "jsp", "ksh", "list", "log", "lsp", "lst", "lsx", "lua", "m", "mk", "mm", "man", "manifest", "mar", "mcf", "md", "mdoc", "me", "ms", "p", "pch", "pas", "patch", "pl", "plist", "pm", "pod", "py", "rake", "rb", "rexx", "roff", "rst", "rt", "rtx", "ru", "s", "scm", "sdml", "sgm", "sgml", "sh", "shtml", "spc", "ssi", "st", "t", "talk", "tcl", "tcsh", "text", "textile", "tr", "tsv", "txt", "uil", "uni", "unis", "uri", "uris", "uu", "uue", "vcf", "vcs", "wml", "wmls", "wsc", "xml", "yaml", "yml", "zsh"]
     }


### PR DESCRIPTION
As you can read at https://developer.chrome.com/apps/manifest/file_handlers, _The title attribute is mandatory on Chrome version 37 and earlier. As of Chrome version 38, it is deprecated and will be ignored (the app's name will be used instead). For compatibility, title should always be the name of the app._

TBR=@eterevsky
