### PR TITLE
Mimic Sublime default Tab behaviour

### DIFF
--- a/js/editor-cm.js
+++ b/js/editor-cm.js
@@ -24,7 +24,8 @@ function EditorCodeMirror(editorElement, settings) {
   this.cm_.on('change', this.onChange.bind(this));
   this.setTheme();
   this.search_ = new Search(this.cm_);
-  this.defaultTabHandler_ = CodeMirror.commands.defaultTab;
+  // Mimic Sublime behaviour there.
+  this.defaultTabHandler_ = function(cm) { cm.execCommand('insertTab'); };
 }
 
 EditorCodeMirror.EXTENSION_TO_MODE = {


### PR DESCRIPTION
As mentioned in the bug below, I'd rather have a Sublime Tab behaviour by default in our Text App.

Before:
`12[34]567` -> `<space><space><space><space>12[34]567`
`[123]457` -> `<space><space><space><space>[123]4567`
`1234|567` -> `1234<tab>567`
Now:
`12[34]567` -> `12<tab>567`
`[123]4567` -> `<tab>4567`
`1234|567` -> `1234<tab>567` (unchanged)

Legend:
`[` and `]` : range selection
`|` : cursor selection

BUG=https://github.com/GoogleChrome/text-app/issues/264
TBR=@eterevsky